### PR TITLE
Update FilamentSubscriptionsPlugin.php

### DIFF
--- a/src/FilamentSubscriptionsPlugin.php
+++ b/src/FilamentSubscriptionsPlugin.php
@@ -67,7 +67,7 @@ class FilamentSubscriptionsPlugin implements Plugin
             if ($this->showUserMenu && !filament()->hasTenancy()) {
                 $panel->userMenuItems([
                     MenuItem::make()
-                        ->label('Manage Subscriptions')
+                        ->label(trans('filament-subscriptions::messages.menu'))
                         ->icon('heroicon-s-credit-card')
                         ->url(route('filament.' . $panel->getId() . '.tenant.billing'))
                 ]);


### PR DESCRIPTION
Change to use existing translation instead of hardcoded label

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced internationalization support by making the menu label for 'Manage Subscriptions' translatable based on the application's locale.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->