### PR TITLE
Update composer.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Users without an active subscription will be redirected to the billing page.
 
 ## Register New Subscriber Type
 
-you can register new subscriber type by using this code
+You can register new subscriber type by using this code
 
 ```php
 use TomatoPHP\FilamentSubscriptions\Facades\FilamentSubscriptions;
@@ -138,6 +138,16 @@ public function boot()
             ->model(\App\Models\User::class)
     );
 }
+```
+
+## Use custom Billing page
+
+You can create your own billing class and register it in `config/laravel-subscriptions.php`
+
+```php
+ 'pages' => [
+        'billing' => Billing::class,
+    ]
 ```
 
 ## Use Events

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "filament/spatie-laravel-media-library-plugin": "^3.0",
         "laravelcm/laravel-subscriptions": "^1.3",
         "tomatophp/console-helpers": "^1.1",
-        "tomatophp/filament-locations": "^1.0",
+        "tomatophp/filament-locations": "^2.0",
         "tomatophp/filament-translation-component": "^1.0"
     }
 }

--- a/config/filament-subscriptions.php
+++ b/config/filament-subscriptions.php
@@ -1,5 +1,19 @@
 <?php
 
+use TomatoPHP\FilamentSubscriptions\Filament\Pages\Billing;
+
+use TomatoPHP\FilamentSubscriptions\Filament\Resources\PlanResource;
+use TomatoPHP\FilamentSubscriptions\Filament\Resources\SubscriptionResource;
+
 return [
-   "route" => "/admin/billing"
+   "route" => "/admin/billing",
+
+   'pages' => [
+      'billing' => Billing::class,
+   ],
+
+   'resources' => [
+      'plan' => PlanResource::class,
+      'subscription' => SubscriptionResource::class,
+   ],
 ];

--- a/src/Filament/Resources/PlanResource.php
+++ b/src/Filament/Resources/PlanResource.php
@@ -18,11 +18,14 @@ use TomatoPHP\FilamentTranslationComponent\Components\Translation;
 
 class PlanResource extends Resource
 {
-    protected static ?string $model = Plan::class;
-
     protected static ?string $navigationIcon = 'heroicon-o-bookmark';
 
     protected static ?int $navigationSort = 1;
+
+    public static function getModel(): string
+    {
+        return config('laravel-subscriptions.models.plan', Plan::class);
+    }
 
     public static function getNavigationGroup(): ?string
     {

--- a/src/Filament/Resources/PlanResource.php
+++ b/src/Filament/Resources/PlanResource.php
@@ -29,7 +29,7 @@ class PlanResource extends Resource
 
     public static function getNavigationGroup(): ?string
     {
-        return trans('filament-subscriptions::messages.group');
+        return config('laravel-subscriptions.navigation.group', trans('filament-subscriptions::messages.group'));
     }
 
     public static function getNavigationLabel(): string

--- a/src/Filament/Resources/SubscriptionResource.php
+++ b/src/Filament/Resources/SubscriptionResource.php
@@ -21,15 +21,18 @@ use TomatoPHP\FilamentSubscriptions\Models\Subscription;
 
 class SubscriptionResource extends Resource
 {
-    protected static ?string $model = Subscription::class;
-
     protected static ?string $navigationIcon = 'heroicon-o-credit-card';
 
     protected static ?int $navigationSort = 2;
 
+    public static function getModel(): string
+    {
+        return config('laravel-subscriptions.models.subscription', Subscription::class);
+    }
+
     public static function getNavigationGroup(): ?string
     {
-        return trans('filament-subscriptions::messages.group');
+        return config('laravel-subscriptions.navigation.group', trans('filament-subscriptions::messages.group'));
     }
 
     public static function getNavigationLabel(): string

--- a/src/FilamentSubscriptionsPlugin.php
+++ b/src/FilamentSubscriptionsPlugin.php
@@ -28,7 +28,7 @@ class FilamentSubscriptionsPlugin implements Plugin
         return $this;
     }
 
-    public function withoutResources(bool $withoutResources = true):static
+    public function withoutResources(bool $withoutResources = true): static
     {
         $this->withoutResources = $withoutResources;
         return $this;
@@ -36,40 +36,42 @@ class FilamentSubscriptionsPlugin implements Plugin
 
     public function register(Panel $panel): void
     {
-        if(class_exists(Module::class) && \Nwidart\Modules\Facades\Module::find('FilamentSubscriptions')?->isEnabled()){
+        if (class_exists(Module::class) && \Nwidart\Modules\Facades\Module::find('FilamentSubscriptions')?->isEnabled()) {
             $this->isActive = true;
-        }
-        else {
+        } else {
             $this->isActive = true;
         }
 
-        if($this->isActive) {
+        if ($this->isActive) {
             $panel
                 ->pages([
-                    config('laravel-subscriptions.pages.billing', Billing::class)
+                    config('filament-subscriptions.pages.billing', Billing::class)
                 ]);
 
             if (!$this->withoutResources) {
                 $panel
                     ->resources([
-                        PlanResource::class,
-                        SubscriptionResource::class,
+                        config('filament-subscriptions.resources.plan', PlanResource::class),
+                        config('filament-subscriptions.resources.subscription', SubscriptionResource::class),
                     ]);
             }
         }
-
-
     }
 
     public function boot(Panel $panel): void
     {
-        if($this->isActive) {
+        if ($this->isActive) {
             if ($this->showUserMenu && !filament()->hasTenancy()) {
                 $panel->userMenuItems([
                     MenuItem::make()
                         ->label(trans('filament-subscriptions::messages.menu'))
                         ->icon('heroicon-s-credit-card')
-                        ->url(route('filament.' . $panel->getId() . '.tenant.billing'))
+                        ->url(
+                            route(
+                                'filament.' . $panel->getId() . '.tenant.billing',
+                                // ['tenant'=> filament()->getTenant()->{filament()->getCurrentPanel()->getTenantSlugAttribute()}]
+                            )
+                        )
                 ]);
             }
         }

--- a/src/FilamentSubscriptionsPlugin.php
+++ b/src/FilamentSubscriptionsPlugin.php
@@ -46,7 +46,7 @@ class FilamentSubscriptionsPlugin implements Plugin
         if($this->isActive) {
             $panel
                 ->pages([
-                    Billing::class
+                    config('laravel-subscriptions.pages.billing', Billing::class)
                 ]);
 
             if (!$this->withoutResources) {

--- a/src/FilamentSubscriptionsPlugin.php
+++ b/src/FilamentSubscriptionsPlugin.php
@@ -69,9 +69,7 @@ class FilamentSubscriptionsPlugin implements Plugin
                     MenuItem::make()
                         ->label(trans('filament-subscriptions::messages.menu'))
                         ->icon('heroicon-s-credit-card')
-                        ->url(route('filament.' . $panel->getId() . '.tenant.billing',
-                                ['tenant'=> filament()->getTenant()->{filament()->getCurrentPanel()->getTenantSlugAttribute()}]
-                            ))
+                        ->url(route('filament.' . $panel->getId() . '.tenant.billing'))
                 ]);
             }
         }

--- a/src/FilamentSubscriptionsPlugin.php
+++ b/src/FilamentSubscriptionsPlugin.php
@@ -69,7 +69,9 @@ class FilamentSubscriptionsPlugin implements Plugin
                     MenuItem::make()
                         ->label(trans('filament-subscriptions::messages.menu'))
                         ->icon('heroicon-s-credit-card')
-                        ->url(route('filament.' . $panel->getId() . '.tenant.billing'))
+                        ->url(route('filament.' . $panel->getId() . '.tenant.billing',
+                                ['tenant'=> filament()->getTenant()->{filament()->getCurrentPanel()->getTenantSlugAttribute()}]
+                            ))
                 ]);
             }
         }


### PR DESCRIPTION
Bump version for peer dependency `tomatophp/filament-locations` which fixes the issues with postgres

Backticks in v1.x sql files are not supported by Postgres. I have seen 2.x moved to json files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Dependencies**
	- Updated `tomatophp/filament-locations` library to version 2.0

- **Code Improvements**
	- Enhanced `PlanResource` to dynamically retrieve model configuration and navigation group
	- Updated `SubscriptionResource` for dynamic model retrieval and navigation group configuration
	- Improved flexibility in billing page configuration within `FilamentSubscriptionsPlugin`

- **Documentation**
	- Added new section "Use custom Billing page" in the README for user guidance on custom billing class registration
<!-- end of auto-generated comment: release notes by coderabbit.ai -->