### PR TITLE
Update billing.blade.php

### DIFF
--- a/resources/views/pages/billing.blade.php
+++ b/resources/views/pages/billing.blade.php
@@ -22,13 +22,13 @@
             <div class="mt-6">
                 {{ trans('filament-subscriptions::messages.view.our_billing_management') }}
             </div>
-            <x-filament::link href="{{ url(filament()->getCurrentPanel()->getId()) }}" class="mt-6" >
+            <x-filament::link href="{{ url(filament()->getCurrentPanel()->getUrl()) }}" class="mt-6" >
                 {{ trans('filament-subscriptions::messages.view.return_to') }}
             </x-filament::link>
         </div>
     </div>
     <div class="w-full lg:flex-1 bg-gray-100 dark:bg-gray-800 h-full overflow-y-auto">
-        <a href="{{ url(filament()->getCurrentPanel()->getId()) }}" id="topNavReturnLink" class="lg:hidden flex items-center w-full px-4 py-4 bg-white shadow-lg">
+        <a href="{{ url(filament()->getCurrentPanel()->getUrl()) }}" id="topNavReturnLink" class="lg:hidden flex items-center w-full px-4 py-4 bg-white shadow-lg">
             <svg viewBox="0 0 20 20" fill="currentColor" class="arrow-left w-4 h-4 text-gray-400">
                 <path fill-rule="evenodd" d="M9.707 16.707a1 1 0 01-1.414 0l-6-6a1 1 0 010-1.414l6-6a1 1 0 011.414 1.414L5.414 9H17a1 1 0 110 2H5.414l4.293 4.293a1 1 0 010 1.414z" clip-rule="evenodd"></path>
             </svg>


### PR DESCRIPTION
### 🔧 Fix: Correct Panel URL Retrieval in Filament  

#### 📝 Description  
This update replaces `getId()` with `getUrl()` to ensure the correct retrieval of the Filament panel’s URL. Using `getId()` returned only the panel identifier, which did not generate a valid link.  

#### ⚡ Changes Made  
- Updated the Blade template to use `filament()->getCurrentPanel()->getUrl()` instead of `getId()`.  
- Ensured the generated link correctly redirects users to the Filament dashboard.  

#### 🛠️ Impact  
✅ Fixes incorrect redirection to `/admin`.  
✅ Improves reliability in generating panel URLs.   ✅ Ensures consistency with Filament's built-in navigation methods.  

#### 🚀 Testing  
- Verified that the panel link correctly redirects to the intended Filament dashboard.  
- Checked compatibility with different panel configurations.  

This fix improves user experience and navigation within Filament's admin panel. 🚀

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated navigation links on the billing page to direct users to the correct panel URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->